### PR TITLE
wire frontend onto v2 read-layer + composite SSE

### DIFF
--- a/src/features/chart/lib/perps-chart.ts
+++ b/src/features/chart/lib/perps-chart.ts
@@ -1,10 +1,11 @@
 /**
  * Perps chart library
  * Handles perps-specific candle data fetching and processing.
- * Uses the /ohlc/:market endpoint (Binance klines format).
+ * Uses /v2/candles/:market (Redis-derived Binance klines shape). Falls back
+ * to the legacy /ohlc/:market only if the v2 feature flag is off.
  */
 import axios from 'axios';
-import { config } from '@/shared/config/constants';
+import { config, API_ROUTES_V2 } from '@/shared/config/constants';
 import {
   HarnessMarketConversionParams,
   lotsPriceToUiWithMarket,
@@ -54,7 +55,10 @@ const MAX_OHLC_LIMIT = 1500;
 export async function fetchPerpsCandles(params: PerpsCandleParams): Promise<Candle[]> {
   const { marketId, tf = '1h', limit, from, to } = params;
 
-  const url = new URL(`${config.devnet.gatewayUrl}/ohlc/${encodeURIComponent(marketId)}`);
+  const path = config.devnet.useV2ReadLayer
+    ? API_ROUTES_V2.candles.replace('{marketId}', encodeURIComponent(marketId))
+    : `/ohlc/${encodeURIComponent(marketId)}`;
+  const url = new URL(`${config.devnet.gatewayUrl}${path}`);
   url.searchParams.set('tf', tf);
 
   // The endpoint expects from/to as Unix seconds.

--- a/src/shared/api/v2-adapter.ts
+++ b/src/shared/api/v2-adapter.ts
@@ -1,0 +1,83 @@
+/**
+ * v2 shape adapters — translate thin `/v2/snapshot/*` responses into the
+ * native-scaled atom shapes the UI already consumes.
+ *
+ * These mirror the transforms in `sse-atom-bridge.ts` but start from the
+ * v2 (Redis key dump) shapes instead of the legacy harness-shaped SSE
+ * payloads. Keeping the atom shapes unchanged means zero UI wiring
+ * changes for the canary.
+ */
+import type { Orderbook, OrderbookItem } from '@/entities/orderbook/model';
+import type { MarketContext } from './sse-atom-bridge';
+import type { V2OrderbookSnapshot, V2OrderbookLevel } from './v2-api';
+
+// ── Orderbook ─────────────────────────────────────────────────────────
+// v2 snapshot delivers one entry per *order* (price + order_id + order detail).
+// The UI atom expects aggregated price levels with quantity totals. Aggregate
+// by price, sum base_lots, then convert lots → native.
+
+function lotsPriceToNative(
+  priceLots: bigint,
+  quoteLotSize: number,
+  baseDecimals: number,
+  baseLotSize: number
+): number {
+  const baseScale = BigInt(10) ** BigInt(baseDecimals);
+  // (price_lots * quote_lot_size * 10^base_decimals) / base_lot_size
+  return Number((priceLots * BigInt(quoteLotSize) * baseScale) / BigInt(Math.max(1, baseLotSize)));
+}
+
+function baseLotsToNative(baseLots: bigint, baseLotSize: number): number {
+  return Number(baseLots * BigInt(baseLotSize));
+}
+
+function aggregateSide(
+  levels: V2OrderbookLevel[],
+  ctx: MarketContext,
+  dir: 'bids' | 'asks'
+): OrderbookItem[] {
+  // Aggregate by price_lots (bigint) to avoid float drift when summing.
+  const byPrice = new Map<string, bigint>();
+  const priceLotsByKey = new Map<string, bigint>();
+
+  for (const lvl of levels) {
+    const o = lvl.order;
+    if (!o) continue;
+    let priceLots: bigint;
+    try {
+      priceLots = BigInt(o.price);
+    } catch {
+      continue;
+    }
+    let sizeLots: bigint;
+    try {
+      sizeLots = BigInt(o.size);
+    } catch {
+      continue;
+    }
+    const key = priceLots.toString();
+    byPrice.set(key, (byPrice.get(key) ?? 0n) + sizeLots);
+    priceLotsByKey.set(key, priceLots);
+  }
+
+  const items: OrderbookItem[] = [];
+  for (const [key, sizeLots] of byPrice.entries()) {
+    const priceLots = priceLotsByKey.get(key)!;
+    items.push({
+      price: lotsPriceToNative(priceLots, ctx.quoteLotSize, ctx.baseDecimals, ctx.baseLotSize),
+      quantity: baseLotsToNative(sizeLots, ctx.baseLotSize),
+    });
+  }
+  // Bids: highest first. Asks: lowest first.
+  items.sort((a, b) => (dir === 'bids' ? b.price - a.price : a.price - b.price));
+  return items;
+}
+
+export function mapV2Orderbook(snap: V2OrderbookSnapshot, ctx: MarketContext): Orderbook {
+  return {
+    bids: aggregateSide(snap.bids, ctx, 'bids'),
+    asks: aggregateSide(snap.asks, ctx, 'asks'),
+    lastUpdateId: Date.now(),
+    lastUpdated: new Date(),
+  };
+}

--- a/src/shared/api/v2-api.ts
+++ b/src/shared/api/v2-api.ts
@@ -1,0 +1,229 @@
+/**
+ * v2 read-layer snapshot fetchers.
+ *
+ * Thin wrappers over `/v2/snapshot/*` on the gateway. Response shapes mirror
+ * the Redis key layout (see `docs/redis-read-layer/schema.md`) — pre-aggregation
+ * happens in the adapters in `v2-adapter.ts`, not here.
+ */
+import axios from 'axios';
+import { config, API_ROUTES_V2 } from '@/shared/config/constants';
+
+const GATEWAY = () => config.devnet.gatewayUrl;
+const VIEW = () => (config.devnet.v2View === 'confirmed' ? 'conf' : 'opt');
+
+// ── Orderbook ─────────────────────────────────────────────────────────
+
+export interface V2OrderDetail {
+  owner: string;
+  price: string;
+  size: string;
+  side: 'bid' | 'ask';
+  ts_ms: number | null;
+  client_id: string | null;
+}
+
+export interface V2OrderbookLevel {
+  price: number;
+  order_id: string;
+  order: V2OrderDetail | null;
+}
+
+export interface V2OrderbookSnapshot {
+  market: number;
+  view: 'opt' | 'conf';
+  depth: number;
+  bids: V2OrderbookLevel[];
+  asks: V2OrderbookLevel[];
+}
+
+export async function fetchV2Orderbook(
+  marketId: string | number,
+  opts: { depth?: number; signal?: AbortSignal } = {}
+): Promise<V2OrderbookSnapshot> {
+  const path = API_ROUTES_V2.snapshot_orderbook.replace('{marketId}', String(marketId));
+  const params: Record<string, string | number> = { view: VIEW() };
+  if (opts.depth) params.depth = opts.depth;
+  const res = await axios.get<V2OrderbookSnapshot>(`${GATEWAY()}${path}`, {
+    params,
+    signal: opts.signal,
+  });
+  return res.data;
+}
+
+// ── Balance ───────────────────────────────────────────────────────────
+
+export interface V2BalanceSnapshot {
+  owner: string;
+  view: 'opt' | 'conf';
+  /** Redis HASH dump: field=asset mint, value=native amount string. */
+  balances: Record<string, string>;
+}
+
+export async function fetchV2Balance(
+  owner: string,
+  opts: { signal?: AbortSignal } = {}
+): Promise<V2BalanceSnapshot> {
+  const path = API_ROUTES_V2.snapshot_balance.replace('{owner}', owner);
+  const res = await axios.get<V2BalanceSnapshot>(`${GATEWAY()}${path}`, {
+    params: { view: VIEW() },
+    signal: opts.signal,
+  });
+  return res.data;
+}
+
+// ── Position ──────────────────────────────────────────────────────────
+
+export interface V2PositionFields {
+  base?: string;
+  quote?: string;
+  open_bid?: string;
+  open_ask?: string;
+  reserved?: string;
+  ts_ms?: string;
+  avg_price?: string;
+  unrealized_pnl?: string;
+  realized_pnl?: string;
+  funding?: string;
+}
+
+export interface V2PositionSnapshot {
+  owner: string;
+  market: number;
+  view: 'opt' | 'conf';
+  position: V2PositionFields;
+}
+
+export async function fetchV2Position(
+  owner: string,
+  marketId: string | number,
+  opts: { signal?: AbortSignal } = {}
+): Promise<V2PositionSnapshot> {
+  const path = API_ROUTES_V2.snapshot_position
+    .replace('{owner}', owner)
+    .replace('{marketId}', String(marketId));
+  const res = await axios.get<V2PositionSnapshot>(`${GATEWAY()}${path}`, {
+    params: { view: VIEW() },
+    signal: opts.signal,
+  });
+  return res.data;
+}
+
+// ── Market metadata ───────────────────────────────────────────────────
+
+export interface V2MarketMeta {
+  oracle_price?: string;
+  stable_price?: string;
+  base_lot_size?: string;
+  quote_lot_size?: string;
+  long_funding?: string;
+  short_funding?: string;
+  maker_fee?: string;
+  taker_fee?: string;
+  settle_token_index?: string;
+  market?: string;
+  ts_ms?: string;
+}
+
+export interface V2MarketSnapshot {
+  market: number;
+  meta: V2MarketMeta;
+}
+
+export async function fetchV2Market(
+  marketId: string | number,
+  opts: { signal?: AbortSignal } = {}
+): Promise<V2MarketSnapshot> {
+  const path = API_ROUTES_V2.snapshot_market.replace('{marketId}', String(marketId));
+  const res = await axios.get<V2MarketSnapshot>(`${GATEWAY()}${path}`, { signal: opts.signal });
+  return res.data;
+}
+
+// ── Markets registry ──────────────────────────────────────────────────
+
+export interface V2MarketsList {
+  markets: Array<{ market: string; meta: V2MarketMeta }>;
+}
+
+export async function fetchV2Markets(opts: { signal?: AbortSignal } = {}): Promise<V2MarketsList> {
+  const res = await axios.get<V2MarketsList>(`${GATEWAY()}${API_ROUTES_V2.markets}`, {
+    signal: opts.signal,
+  });
+  return res.data;
+}
+
+// ── Trades ────────────────────────────────────────────────────────────
+
+export interface V2TradeRow {
+  /** Redis stream id. */
+  id: string;
+  maker?: string;
+  taker?: string;
+  price?: string;
+  size?: string;
+  side?: 'bid' | 'ask';
+  ts_ms?: string;
+  sequence?: string;
+}
+
+export interface V2TradesResponse {
+  market: number;
+  trades: V2TradeRow[];
+}
+
+export async function fetchV2Trades(
+  marketId: string | number,
+  opts: { limit?: number; signal?: AbortSignal } = {}
+): Promise<V2TradesResponse> {
+  const path = API_ROUTES_V2.trades.replace('{marketId}', String(marketId));
+  const res = await axios.get<V2TradesResponse>(`${GATEWAY()}${path}`, {
+    params: { limit: opts.limit ?? 50 },
+    signal: opts.signal,
+  });
+  return res.data;
+}
+
+// ── Account composite (balance + per-market positions + margin) ───────
+
+export interface V2AccountSnapshot {
+  balances?: Record<string, string | unknown>;
+  margin_summary?: Record<string, unknown>;
+  positions?: Record<string, Record<string, string>>;
+}
+
+export async function fetchV2Account(
+  owner: string,
+  opts: { signal?: AbortSignal } = {}
+): Promise<V2AccountSnapshot> {
+  const path = API_ROUTES_V2.snapshot_account.replace('{owner}', owner);
+  const res = await axios.get<V2AccountSnapshot>(`${GATEWAY()}${path}`, {
+    params: { view: VIEW() },
+    signal: opts.signal,
+  });
+  return res.data;
+}
+
+// ── Orders index (per-owner) ──────────────────────────────────────────
+
+export interface V2OrdersRow {
+  order_id: string;
+  market: string;
+  order?: V2OrderDetail | null;
+}
+
+export interface V2OrdersSnapshot {
+  owner: string;
+  view: 'opt' | 'conf';
+  orders: V2OrdersRow[];
+}
+
+export async function fetchV2Orders(
+  owner: string,
+  opts: { signal?: AbortSignal } = {}
+): Promise<V2OrdersSnapshot> {
+  const path = API_ROUTES_V2.snapshot_orders.replace('{owner}', owner);
+  const res = await axios.get<V2OrdersSnapshot>(`${GATEWAY()}${path}`, {
+    params: { view: VIEW() },
+    signal: opts.signal,
+  });
+  return res.data;
+}

--- a/src/shared/api/v2-composite-sse-client.ts
+++ b/src/shared/api/v2-composite-sse-client.ts
@@ -1,0 +1,230 @@
+/**
+ * v2 composite SSE client — subscribes to `/v2/stream/frontend/:market?owner=X`.
+ *
+ * Replaces the `v2-sse-client.ts` + `tradesClient` + REST-poll-account trio
+ * with a single connection that multiplexes:
+ *
+ *   event: hello      – connection ack (ignored)
+ *   event: book       – orderbook snapshot on change (every ~250ms)
+ *   event: meta       – market pricing on change (every ~2s)
+ *   event: trade      – live fill from v1:trades:<market>
+ *   event: intent     – relay_intent_status / queue_item_* from v1:events:<market>
+ *   event: account    – balance + position + orders snapshot on change (every ~1s)
+ *   event: ready      – initial burst complete
+ *   event: resync     – broadcast buffer lag; consumer should re-snapshot
+ *
+ * Event payloads carry the whole snapshot so consumers can update atoms
+ * directly without a REST refetch (except the `book` event, which today
+ * carries only price+order_id; consumers keep the debounced /v2/snapshot
+ * fallback for book detail).
+ */
+import { config, API_ROUTES_V2 } from '@/shared/config/constants';
+import type { SSEConnectionState } from './sse-types';
+
+const INITIAL_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30_000;
+const STALE_TIMEOUT_MS = 15_000;
+
+export type V2CompositeEventType =
+  | 'hello'
+  | 'book'
+  | 'meta'
+  | 'trade'
+  | 'intent'
+  | 'account'
+  | 'ready'
+  | 'resync';
+
+export interface V2CompositeEvent<T = unknown> {
+  id: string;
+  event_type: V2CompositeEventType;
+  data: T;
+}
+
+export interface V2CompositeCallbacks {
+  onBook?: (data: unknown) => void;
+  onMeta?: (data: unknown) => void;
+  onTrade?: (data: unknown) => void;
+  onIntent?: (data: unknown) => void;
+  onAccount?: (data: unknown) => void;
+  onReady?: () => void;
+  onResync?: () => void;
+  onStateChange?: (state: SSEConnectionState) => void;
+}
+
+export class V2CompositeSSEClient {
+  private eventSource: EventSource | null = null;
+  private market: string | null = null;
+  private owner: string | null = null;
+  private state: SSEConnectionState = 'disconnected';
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private staleTimer: ReturnType<typeof setTimeout> | null = null;
+  private destroyed = false;
+
+  callbacks: V2CompositeCallbacks = {};
+
+  connect(market: string, owner: string | null) {
+    this.market = market;
+    this.owner = owner;
+    this.reconnectAttempts = 0;
+    this.openConnection();
+  }
+
+  disconnect() {
+    this.closeConnection();
+    this.clearReconnectTimer();
+    this.clearStaleTimer();
+    this.setState('disconnected');
+  }
+
+  switchMarket(market: string) {
+    if (this.market === market) return;
+    this.market = market;
+    this.reconnectAttempts = 0;
+    this.closeConnection();
+    this.clearReconnectTimer();
+    this.openConnection();
+  }
+
+  switchOwner(owner: string | null) {
+    if (this.owner === owner) return;
+    this.owner = owner;
+    if (this.state === 'disconnected') return;
+    // Owner changes require a new connection because ?owner= is attached at
+    // connect time on the gateway.
+    this.reconnectAttempts = 0;
+    this.closeConnection();
+    this.clearReconnectTimer();
+    this.openConnection();
+  }
+
+  getState(): SSEConnectionState {
+    return this.state;
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.disconnect();
+  }
+
+  private buildUrl(): string {
+    const path = API_ROUTES_V2.stream_frontend.replace('{marketId}', this.market ?? '');
+    const base = `${config.devnet.gatewayUrl}${path}`;
+    if (this.owner) return `${base}?owner=${encodeURIComponent(this.owner)}`;
+    return base;
+  }
+
+  private openConnection() {
+    if (this.destroyed || !this.market) return;
+    this.closeConnection();
+    this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
+
+    const es = new EventSource(this.buildUrl());
+    this.eventSource = es;
+
+    const handlers: Array<[V2CompositeEventType, (data: unknown) => void]> = [
+      ['book', d => this.callbacks.onBook?.(d)],
+      ['meta', d => this.callbacks.onMeta?.(d)],
+      ['trade', d => this.callbacks.onTrade?.(d)],
+      ['intent', d => this.callbacks.onIntent?.(d)],
+      ['account', d => this.callbacks.onAccount?.(d)],
+    ];
+    for (const [name, fn] of handlers) {
+      es.addEventListener(name, (e: MessageEvent) => {
+        this.resetStaleTimer();
+        let parsed: unknown = null;
+        try {
+          parsed = JSON.parse(e.data);
+        } catch {
+          /* ignore malformed */
+        }
+        fn(parsed);
+      });
+    }
+    es.addEventListener('hello', () => {
+      this.resetStaleTimer();
+    });
+    es.addEventListener('ready', () => {
+      this.resetStaleTimer();
+      this.callbacks.onReady?.();
+    });
+    es.addEventListener('resync', () => {
+      this.resetStaleTimer();
+      this.callbacks.onResync?.();
+    });
+
+    es.onopen = () => {
+      this.reconnectAttempts = 0;
+      this.setState('connected');
+      this.resetStaleTimer();
+    };
+    es.onerror = () => {
+      this.closeConnection();
+      this.scheduleReconnect();
+    };
+  }
+
+  private closeConnection() {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    this.clearStaleTimer();
+  }
+
+  private scheduleReconnect() {
+    if (this.destroyed) return;
+    this.clearReconnectTimer();
+    const base = Math.min(INITIAL_BACKOFF_MS * 2 ** this.reconnectAttempts, MAX_BACKOFF_MS);
+    const delay = base + Math.random() * base * 0.3;
+    this.reconnectAttempts++;
+    this.setState('reconnecting');
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.openConnection();
+    }, delay);
+  }
+
+  private clearReconnectTimer() {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private resetStaleTimer() {
+    this.clearStaleTimer();
+    this.staleTimer = setTimeout(() => {
+      this.closeConnection();
+      this.scheduleReconnect();
+    }, STALE_TIMEOUT_MS);
+  }
+
+  private clearStaleTimer() {
+    if (this.staleTimer) {
+      clearTimeout(this.staleTimer);
+      this.staleTimer = null;
+    }
+  }
+
+  private setState(state: SSEConnectionState) {
+    if (this.state === state) return;
+    this.state = state;
+    this.callbacks.onStateChange?.(state);
+  }
+}
+
+let instance: V2CompositeSSEClient | null = null;
+
+export function getV2CompositeClient(): V2CompositeSSEClient {
+  if (!instance) instance = new V2CompositeSSEClient();
+  return instance;
+}
+
+export function resetV2CompositeClient(): void {
+  if (instance) {
+    instance.destroy();
+    instance = null;
+  }
+}

--- a/src/shared/api/v2-sse-client.ts
+++ b/src/shared/api/v2-sse-client.ts
@@ -1,0 +1,237 @@
+/**
+ * v2 SSE client — subscribes to `/v2/events/:marketId` on the gateway.
+ *
+ * Unlike the legacy /state/stream/frontend stream, v2 carries raw harness
+ * mutation events (one of `relay_intent_accepted`, `relay_intent_status`,
+ * `queue_item_enqueued`, `queue_item_processed`) plus a `resync` marker when
+ * the server-side broadcast buffer lags. Consumers treat each event as an
+ * invalidation signal and re-fetch snapshots via `/v2/snapshot/*`.
+ *
+ * Resume: EventSource automatically sends `Last-Event-ID` on reconnect; the
+ * gateway accepts that and replays from the last seen stream id up to
+ * MAX_BACKFILL. We also set `?from=` on manual reconnect paths as a belt-
+ * and-suspenders fallback.
+ */
+import { config, API_ROUTES_V2 } from '@/shared/config/constants';
+import type { SSEConnectionState } from './sse-types';
+
+const INITIAL_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30_000;
+const STALE_TIMEOUT_MS = 15_000;
+
+export type V2EventType =
+  | 'relay_intent_accepted'
+  | 'relay_intent_status'
+  | 'queue_item_enqueued'
+  | 'queue_item_processed'
+  | 'reconciliation'
+  | 'resync'
+  | 'backfill_error';
+
+export interface V2StreamEvent {
+  /** Redis stream id — use this as the resume cursor. */
+  id: string;
+  event_type: V2EventType | string;
+  view?: 'opt' | 'conf';
+  ts_ms?: number;
+  sequence?: number;
+  /** Parsed JSON payload. Shape depends on event_type — consumers do not
+   *  interpret this directly; they treat the event as an invalidation
+   *  signal and re-fetch snapshots. */
+  payload?: unknown;
+  /** Raw field map in case a future consumer needs it. */
+  raw: Record<string, unknown>;
+}
+
+export interface V2SSECallbacks {
+  onEvent?: (ev: V2StreamEvent) => void;
+  onResync?: () => void;
+  onStateChange?: (state: SSEConnectionState) => void;
+}
+
+export class V2SSEClient {
+  private eventSource: EventSource | null = null;
+  private market: string | null = null;
+  private lastEventId: string | null = null;
+  private state: SSEConnectionState = 'disconnected';
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private staleTimer: ReturnType<typeof setTimeout> | null = null;
+  private destroyed = false;
+
+  callbacks: V2SSECallbacks = {};
+
+  connect(market: string) {
+    this.market = market;
+    this.reconnectAttempts = 0;
+    this.lastEventId = null;
+    this.openConnection();
+  }
+
+  disconnect() {
+    this.closeConnection();
+    this.clearReconnectTimer();
+    this.clearStaleTimer();
+    this.setState('disconnected');
+  }
+
+  switchMarket(market: string) {
+    if (this.market === market) return;
+    this.market = market;
+    this.lastEventId = null;
+    this.reconnectAttempts = 0;
+    this.closeConnection();
+    this.clearReconnectTimer();
+    this.openConnection();
+  }
+
+  getState(): SSEConnectionState {
+    return this.state;
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.disconnect();
+  }
+
+  private buildUrl(): string {
+    const path = API_ROUTES_V2.events.replace('{marketId}', this.market ?? '');
+    const base = `${config.devnet.gatewayUrl}${path}`;
+    // EventSource sends `Last-Event-ID` automatically on reconnect via the
+    // native retry loop, but we drive our own reconnects; `?from=` covers
+    // both the manual reconnect path and user agents that drop the header
+    // after EventSource.close().
+    if (this.lastEventId) {
+      return `${base}?from=${encodeURIComponent(this.lastEventId)}`;
+    }
+    return base;
+  }
+
+  private openConnection() {
+    if (this.destroyed || !this.market) return;
+    this.closeConnection();
+
+    this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
+
+    const es = new EventSource(this.buildUrl());
+    this.eventSource = es;
+
+    const eventTypes: V2EventType[] = [
+      'relay_intent_accepted',
+      'relay_intent_status',
+      'queue_item_enqueued',
+      'queue_item_processed',
+      'reconciliation',
+      'backfill_error',
+    ];
+    for (const t of eventTypes) {
+      es.addEventListener(t, (e: MessageEvent) => this.handleEvent(t, e));
+    }
+    es.addEventListener('resync', () => {
+      this.resetStaleTimer();
+      this.callbacks.onResync?.();
+    });
+
+    es.onopen = () => {
+      this.reconnectAttempts = 0;
+      this.setState('connected');
+      this.resetStaleTimer();
+    };
+    es.onerror = () => {
+      this.closeConnection();
+      this.scheduleReconnect();
+    };
+  }
+
+  private handleEvent(eventType: V2EventType, e: MessageEvent) {
+    this.resetStaleTimer();
+
+    if (e.lastEventId) this.lastEventId = e.lastEventId;
+
+    let obj: Record<string, unknown> = {};
+    try {
+      const parsed = JSON.parse(e.data);
+      if (parsed && typeof parsed === 'object') obj = parsed as Record<string, unknown>;
+    } catch {
+      // Malformed payload — fire the event anyway so consumers still
+      // treat it as an invalidation signal.
+    }
+
+    const ev: V2StreamEvent = {
+      id: e.lastEventId || '',
+      event_type: (obj.event_type as string) || eventType,
+      view: (obj.view as 'opt' | 'conf' | undefined) ?? undefined,
+      ts_ms: typeof obj.ts_ms === 'string' ? Number(obj.ts_ms) : (obj.ts_ms as number | undefined),
+      sequence:
+        typeof obj.sequence === 'string'
+          ? Number(obj.sequence)
+          : (obj.sequence as number | undefined),
+      payload: obj.payload,
+      raw: obj,
+    };
+    this.callbacks.onEvent?.(ev);
+  }
+
+  private closeConnection() {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    this.clearStaleTimer();
+  }
+
+  private scheduleReconnect() {
+    if (this.destroyed) return;
+    this.clearReconnectTimer();
+    const base = Math.min(INITIAL_BACKOFF_MS * 2 ** this.reconnectAttempts, MAX_BACKOFF_MS);
+    const delay = base + Math.random() * base * 0.3;
+    this.reconnectAttempts++;
+    this.setState('reconnecting');
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.openConnection();
+    }, delay);
+  }
+
+  private clearReconnectTimer() {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private resetStaleTimer() {
+    this.clearStaleTimer();
+    this.staleTimer = setTimeout(() => {
+      this.closeConnection();
+      this.scheduleReconnect();
+    }, STALE_TIMEOUT_MS);
+  }
+
+  private clearStaleTimer() {
+    if (this.staleTimer) {
+      clearTimeout(this.staleTimer);
+      this.staleTimer = null;
+    }
+  }
+
+  private setState(state: SSEConnectionState) {
+    if (this.state === state) return;
+    this.state = state;
+    this.callbacks.onStateChange?.(state);
+  }
+}
+
+let instance: V2SSEClient | null = null;
+
+export function getV2SSEClient(): V2SSEClient {
+  if (!instance) instance = new V2SSEClient();
+  return instance;
+}
+
+export function resetV2SSEClient(): void {
+  if (instance) {
+    instance.destroy();
+    instance = null;
+  }
+}

--- a/src/shared/api/walletTrades.ts
+++ b/src/shared/api/walletTrades.ts
@@ -8,16 +8,63 @@ export interface FetchWalletTradesParams {
   signal?: AbortSignal;
 }
 
+/**
+ * v2 wallet-trades row — Redis stream entry shape from
+ * `v1:wallet_trades:<owner>` populated by the harness publisher.
+ */
+interface V2WalletTradeRow {
+  id: string;
+  market?: string;
+  maker?: string;
+  taker?: string;
+  price?: string;
+  size?: string;
+  side?: 'bid' | 'ask';
+  ts_ms?: string;
+  sequence?: string;
+}
+
+/**
+ * Translate the v2 wallet-trade row shape to the legacy `SSETrade` shape
+ * the UI consumers expect. Field names differ (price → price_lots,
+ * size → base_lots, side → taker_side, etc.) but the data is the same.
+ */
+function v2WalletTradeToSSE(row: V2WalletTradeRow): SSETrade {
+  const ts = Number(row.ts_ms ?? 0);
+  return {
+    trade_id: row.id,
+    market: row.market ?? '',
+    maker_owner: row.maker ?? '',
+    taker_owner: row.taker ?? '',
+    taker_side: (row.side ?? 'bid') as 'bid' | 'ask',
+    price_lots: row.price ?? '0',
+    base_lots: row.size ?? '0',
+    quote_lots: '0',
+    ts_ms: Number.isFinite(ts) ? ts : 0,
+    taker_sequence: row.sequence ?? '0',
+    // Optional fields present on some v1 payloads — null-safe absence is fine.
+  } as SSETrade;
+}
+
 export async function fetchWalletTrades(
   pubkey: string,
   { market, limit = 50, before, signal }: FetchWalletTradesParams = {}
 ): Promise<SSETrade[]> {
   const params = new URLSearchParams();
-  if (market) params.set('market', market);
   if (limit) params.set('limit', String(limit));
-  if (before !== undefined) params.set('before', String(before));
   const qs = params.toString();
-  const url = `${config.devnet.gatewayUrl}/wallet/${pubkey}/trades${qs ? `?${qs}` : ''}`;
+
+  // v2 path (Redis-backed fan-out stream). Legacy /wallet/:pubkey/trades stays
+  // behind the feature flag until the v1 route is retired.
+  const path = config.devnet.useV2ReadLayer
+    ? `/v2/trades/wallet/${encodeURIComponent(pubkey)}${qs ? `?${qs}` : ''}`
+    : (() => {
+        if (market) params.set('market', market);
+        if (before !== undefined) params.set('before', String(before));
+        const legacyQs = params.toString();
+        return `/wallet/${pubkey}/trades${legacyQs ? `?${legacyQs}` : ''}`;
+      })();
+  const url = `${config.devnet.gatewayUrl}${path}`;
 
   const res = await fetch(url, { signal });
   if (!res.ok) {
@@ -31,6 +78,13 @@ export async function fetchWalletTrades(
     throw new Error(message);
   }
 
-  const data = (await res.json()) as SSETrade[];
+  const data = await res.json();
+  if (config.devnet.useV2ReadLayer) {
+    const rows = (data?.trades ?? []) as V2WalletTradeRow[];
+    let mapped = rows.map(v2WalletTradeToSSE);
+    // Client-side `market` filter for parity with the legacy server-side one.
+    if (market) mapped = mapped.filter(t => t.market === market);
+    return mapped;
+  }
   return Array.isArray(data) ? data : [];
 }

--- a/src/shared/api/walletTrades.ts
+++ b/src/shared/api/walletTrades.ts
@@ -10,11 +10,17 @@ export interface FetchWalletTradesParams {
 
 /**
  * v2 wallet-trades row — Redis stream entry shape from
- * `v1:wallet_trades:<owner>` populated by the harness publisher.
+ * `v1:wallet_trades:<owner>` populated by the harness publisher. The
+ * publisher emits both shorthand (maker/taker/price/size/side) and legacy
+ * alias (maker_owner/taker_owner/price_lots/base_lots/quote_lots/taker_side/
+ * maker_order_id/taker_sequence/trade_id) field names on every entry.
+ * Readers prefer the legacy shape because it matches the TSDB schema and
+ * the existing SSETrade consumer contract verbatim.
  */
 interface V2WalletTradeRow {
   id: string;
   market?: string;
+  // Shorthand (always present).
   maker?: string;
   taker?: string;
   price?: string;
@@ -22,27 +28,38 @@ interface V2WalletTradeRow {
   side?: 'bid' | 'ask';
   ts_ms?: string;
   sequence?: string;
+  // Legacy aliases (preferred when present).
+  trade_id?: string;
+  maker_owner?: string;
+  taker_owner?: string;
+  price_lots?: string;
+  base_lots?: string;
+  quote_lots?: string;
+  taker_side?: 'bid' | 'ask';
+  maker_order_id?: string;
+  taker_sequence?: string;
 }
 
 /**
  * Translate the v2 wallet-trade row shape to the legacy `SSETrade` shape
- * the UI consumers expect. Field names differ (price → price_lots,
- * size → base_lots, side → taker_side, etc.) but the data is the same.
+ * the UI consumers expect. Prefer the legacy-alias fields because they map
+ * to SSETrade field names verbatim; fall back to shorthand so an older
+ * publisher build still works.
  */
 function v2WalletTradeToSSE(row: V2WalletTradeRow): SSETrade {
   const ts = Number(row.ts_ms ?? 0);
   return {
-    trade_id: row.id,
+    trade_id: row.trade_id ?? row.id,
     market: row.market ?? '',
-    maker_owner: row.maker ?? '',
-    taker_owner: row.taker ?? '',
-    taker_side: (row.side ?? 'bid') as 'bid' | 'ask',
-    price_lots: row.price ?? '0',
-    base_lots: row.size ?? '0',
-    quote_lots: '0',
+    maker_owner: row.maker_owner ?? row.maker ?? '',
+    taker_owner: row.taker_owner ?? row.taker ?? '',
+    taker_side: (row.taker_side ?? row.side ?? 'bid') as 'bid' | 'ask',
+    price_lots: row.price_lots ?? row.price ?? '0',
+    base_lots: row.base_lots ?? row.size ?? '0',
+    quote_lots: row.quote_lots ?? '0',
     ts_ms: Number.isFinite(ts) ? ts : 0,
-    taker_sequence: row.sequence ?? '0',
-    // Optional fields present on some v1 payloads — null-safe absence is fine.
+    maker_order_id: row.maker_order_id,
+    taker_sequence: row.taker_sequence ?? row.sequence ?? '0',
   } as SSETrade;
 }
 
@@ -50,21 +67,41 @@ export async function fetchWalletTrades(
   pubkey: string,
   { market, limit = 50, before, signal }: FetchWalletTradesParams = {}
 ): Promise<SSETrade[]> {
-  const params = new URLSearchParams();
-  if (limit) params.set('limit', String(limit));
-  const qs = params.toString();
-
   // v2 path (Redis-backed fan-out stream). Legacy /wallet/:pubkey/trades stays
   // behind the feature flag until the v1 route is retired.
-  const path = config.devnet.useV2ReadLayer
-    ? `/v2/trades/wallet/${encodeURIComponent(pubkey)}${qs ? `?${qs}` : ''}`
-    : (() => {
-        if (market) params.set('market', market);
-        if (before !== undefined) params.set('before', String(before));
-        const legacyQs = params.toString();
-        return `/wallet/${pubkey}/trades${legacyQs ? `?${legacyQs}` : ''}`;
-      })();
-  const url = `${config.devnet.gatewayUrl}${path}`;
+  if (config.devnet.useV2ReadLayer) {
+    const params = new URLSearchParams();
+    if (limit) params.set('limit', String(limit));
+    // Server-side market filter — the gateway over-reads from the fan-out
+    // stream and filters before trimming, so a single-market query returns
+    // `limit` trades from that market instead of `limit` trades across all
+    // markets post-filtered to potentially zero.
+    if (market) params.set('market', market);
+    const qs = params.toString();
+    const url = `${config.devnet.gatewayUrl}/v2/trades/wallet/${encodeURIComponent(pubkey)}${qs ? `?${qs}` : ''}`;
+    const res = await fetch(url, { signal });
+    if (!res.ok) {
+      let message = `Failed to fetch wallet trades (${res.status})`;
+      try {
+        const body = await res.json();
+        if (body?.error) message = body.error;
+      } catch {
+        /* ignore json parse error */
+      }
+      throw new Error(message);
+    }
+    const data = await res.json();
+    const rows = (data?.trades ?? []) as V2WalletTradeRow[];
+    return rows.map(v2WalletTradeToSSE);
+  }
+
+  // Legacy v1 path.
+  const params = new URLSearchParams();
+  if (market) params.set('market', market);
+  if (limit) params.set('limit', String(limit));
+  if (before !== undefined) params.set('before', String(before));
+  const qs = params.toString();
+  const url = `${config.devnet.gatewayUrl}/wallet/${pubkey}/trades${qs ? `?${qs}` : ''}`;
 
   const res = await fetch(url, { signal });
   if (!res.ok) {
@@ -79,12 +116,5 @@ export async function fetchWalletTrades(
   }
 
   const data = await res.json();
-  if (config.devnet.useV2ReadLayer) {
-    const rows = (data?.trades ?? []) as V2WalletTradeRow[];
-    let mapped = rows.map(v2WalletTradeToSSE);
-    // Client-side `market` filter for parity with the legacy server-side one.
-    if (market) mapped = mapped.filter(t => t.market === market);
-    return mapped;
-  }
   return Array.isArray(data) ? data : [];
 }

--- a/src/shared/config/constants.ts
+++ b/src/shared/config/constants.ts
@@ -27,6 +27,10 @@ export const config = {
     quoteLotSize: Number(import.meta.env.VITE_QUOTE_LOT_SIZE || 10),
     quoteTokenName: import.meta.env.VITE_QUOTE_TOKEN_SYMBOL || 'USDC',
     baseTokenName: import.meta.env.VITE_BASE_TOKEN_SYMBOL || 'SOL',
+    // Phase 4 canary: flip to use the Redis-backed /v2/* read layer on the
+    // gateway instead of the legacy /state/* harness-proxy endpoints.
+    useV2ReadLayer: (import.meta.env.VITE_USE_V2_READ_LAYER || 'false').toLowerCase() === 'true',
+    v2View: (import.meta.env.VITE_V2_VIEW || 'optimistic') as 'optimistic' | 'confirmed',
   },
 };
 
@@ -58,6 +62,26 @@ export const SelfTradeBehavior = {
   DecrementTake: { decrementTake: {} },
   CancelProvide: { cancelProvide: {} },
   AbortTransaction: { abortTransaction: {} },
+};
+
+// Phase 4 canary: new Redis-backed read-layer routes. Served directly from the
+// gateway; no harness in the hot path. Gated behind `config.devnet.useV2ReadLayer`.
+export const API_ROUTES_V2 = {
+  healthz: '/v2/healthz',
+  markets: '/v2/markets',
+  snapshot_orderbook: '/v2/snapshot/orderbook/{marketId}',
+  snapshot_balance: '/v2/snapshot/balance/{owner}',
+  snapshot_position: '/v2/snapshot/position/{owner}/{marketId}',
+  snapshot_market: '/v2/snapshot/market/{marketId}',
+  snapshot_account: '/v2/snapshot/account/{owner}',
+  snapshot_orders: '/v2/snapshot/orders/{owner}',
+  trades: '/v2/trades/{marketId}',
+  candles: '/v2/candles/{marketId}',
+  stats_volume_24h: '/v2/stats/volume/24h',
+  events: '/v2/events/{marketId}',
+  snapshot_and_stream: '/v2/events/snapshot-and-stream/{marketId}',
+  stream_frontend: '/v2/stream/frontend/{marketId}',
+  stream_trades: '/v2/stream/trades',
 };
 
 export const API_ROUTES = {

--- a/src/shared/hooks/useSSEStream.ts
+++ b/src/shared/hooks/useSSEStream.ts
@@ -22,6 +22,9 @@ import {
   recentMarketTradesAtom,
 } from '@/shared/api/sse-atoms';
 import { getSSEClient, getTradesSSEClient } from '@/shared/api/sse-client';
+import { getV2CompositeClient } from '@/shared/api/v2-composite-sse-client';
+import { fetchV2Orderbook, fetchV2Trades } from '@/shared/api/v2-api';
+import { mapV2Orderbook } from '@/shared/api/v2-adapter';
 import {
   buildContextFromMarket,
   buildMarketContext,
@@ -159,6 +162,111 @@ export function useSSEStream() {
     if (data.owner) handleAccountUpdate(data.owner);
   }
 
+  // --- v2 read-layer (Phase 5) ------------------------------
+  // When enabled, subscribe to /v2/stream/frontend/:market?owner=X as a
+  // single composite stream. Events are used as invalidation signals:
+  //   - `book`    → debounced refetch /v2/snapshot/orderbook
+  //   - `trade`   → debounced refetch /v2/trades
+  //   - `intent`  → debounced refetch /v2/trades (new fills often show up here first)
+  //   - `account` → (future: refetch /v2/snapshot/account + /v2/snapshot/orders)
+  //   - `meta`    → currently no-op; market metrics still driven by the v1 path
+  //                 fallback until metricsAtom has a v2 source of truth.
+  // One SSE connection replaces the prior event/trades dual-stream plus the
+  // explicit REST poll loop.
+  const v2Enabled = config.devnet.useV2ReadLayer;
+  const v2Composite = getV2CompositeClient();
+  const currentMarketRef = useRef<string | null>(marketId);
+  currentMarketRef.current = marketId;
+
+  const orderbookRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const orderbookRefetchAbortRef = useRef<AbortController | null>(null);
+  const tradesRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tradesRefetchAbortRef = useRef<AbortController | null>(null);
+
+  function scheduleOrderbookRefetch() {
+    if (!v2Enabled) return;
+    if (orderbookRefetchTimerRef.current) return;
+    orderbookRefetchTimerRef.current = setTimeout(async () => {
+      orderbookRefetchTimerRef.current = null;
+      const mid = currentMarketRef.current;
+      if (!mid) return;
+      const market = markets.find(m => m.uuid === mid);
+      const ctx = market ? buildContextFromMarket(market) : ctxMapRef.current.get(mid);
+      if (!ctx) return;
+      orderbookRefetchAbortRef.current?.abort();
+      const controller = new AbortController();
+      orderbookRefetchAbortRef.current = controller;
+      try {
+        const snap = await fetchV2Orderbook(mid, { signal: controller.signal });
+        if (controller.signal.aborted) return;
+        setOrderbook(mapV2Orderbook(snap, ctx));
+      } catch {
+        /* transient; next event will re-trigger */
+      }
+    }, 50);
+  }
+
+  function scheduleTradesRefetch() {
+    if (!v2Enabled) return;
+    if (tradesRefetchTimerRef.current) return;
+    tradesRefetchTimerRef.current = setTimeout(async () => {
+      tradesRefetchTimerRef.current = null;
+      const mid = currentMarketRef.current;
+      if (!mid) return;
+      const market = markets.find(m => m.uuid === mid);
+      const ctx = market ? buildContextFromMarket(market) : ctxMapRef.current.get(mid);
+      if (!ctx) return;
+      tradesRefetchAbortRef.current?.abort();
+      const controller = new AbortController();
+      tradesRefetchAbortRef.current = controller;
+      try {
+        const resp = await fetchV2Trades(mid, {
+          limit: RECENT_TRADES_MAX,
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted) return;
+        // The v2 /trades response shape is `{market, trades: [{id, maker, taker, price, size, side, ts_ms}]}`.
+        // Translate to RecentTrade (native-scaled price/qty using market ctx).
+        const baseScale = 10 ** ctx.baseDecimals;
+        const mapped = resp.trades.map(t => {
+          const priceLots = t.price ? BigInt(t.price) : 0n;
+          const sizeLots = t.size ? BigInt(t.size) : 0n;
+          const price = Number(
+            (priceLots * BigInt(ctx.quoteLotSize) * BigInt(baseScale)) /
+              BigInt(Math.max(1, ctx.baseLotSize))
+          );
+          const quantity = Number(sizeLots * BigInt(ctx.baseLotSize));
+          const takerSide = t.side === 'bid' ? 'bid' : 'ask';
+          return {
+            id: t.id,
+            price,
+            quantity,
+            timestamp: Math.floor(Number(t.ts_ms ?? 0) / 1000),
+            buyer_owner: takerSide === 'bid' ? (t.taker ?? '') : (t.maker ?? ''),
+            seller_owner: takerSide === 'ask' ? (t.taker ?? '') : (t.maker ?? ''),
+          };
+        });
+        setRecentTrades(prev => mergeRecentTrades(mapped, prev));
+      } catch {
+        /* transient; next event will re-trigger */
+      }
+    }, 100);
+  }
+
+  v2Composite.callbacks.onStateChange = setConnectionState;
+  v2Composite.callbacks.onBook = () => scheduleOrderbookRefetch();
+  v2Composite.callbacks.onTrade = () => scheduleTradesRefetch();
+  v2Composite.callbacks.onIntent = () => scheduleTradesRefetch();
+  v2Composite.callbacks.onResync = () => {
+    scheduleOrderbookRefetch();
+    scheduleTradesRefetch();
+  };
+  v2Composite.callbacks.onReady = () => {
+    // Eager seed: gateway already pushed the first book+meta; kick a trades
+    // refetch too so the panel is populated immediately.
+    scheduleTradesRefetch();
+  };
+
   // --- Wire callbacks into the singleton clients via mutable ref ---
   const client = getSSEClient();
   client.callbacks.onStateChange = setConnectionState;
@@ -202,10 +310,17 @@ export function useSSEStream() {
     tradesPrefetchAbortRef.current = controller;
 
     try {
-      const url = `${config.devnet.gatewayUrl}/market/${targetMarketId}/trades/recent?limit=${RECENT_TRADES_PREFETCH_LIMIT}`;
+      // v2 path (Redis-backed) is preferred; legacy /market/:id/trades/recent
+      // kept as fallback until we fully retire /state/*.
+      const path = config.devnet.useV2ReadLayer
+        ? `/v2/trades/${encodeURIComponent(targetMarketId)}?limit=${RECENT_TRADES_PREFETCH_LIMIT}`
+        : `/market/${targetMarketId}/trades/recent?limit=${RECENT_TRADES_PREFETCH_LIMIT}`;
+      const url = `${config.devnet.gatewayUrl}${path}`;
       const res = await fetch(url, { signal: controller.signal });
       if (!res.ok) return;
-      const trades = (await res.json()) as SSETrade[];
+      const body = await res.json();
+      // v2 returns {market, trades: [...]}; legacy returns the array directly.
+      const trades = (Array.isArray(body) ? body : (body?.trades ?? [])) as SSETrade[];
       if (controller.signal.aborted) return;
       if (!Array.isArray(trades) || trades.length === 0) return;
 
@@ -227,12 +342,23 @@ export function useSSEStream() {
   useEffect(() => {
     if (marketId) {
       prefetchRecentTrades(marketId);
-      client.connect(marketId, publicKey?.toBase58() ?? null);
-      tradesClient.connect(marketId);
+      if (v2Enabled) {
+        v2Composite.connect(marketId, publicKey?.toBase58() ?? null);
+        // Seed orderbook immediately — don't wait for the first event.
+        scheduleOrderbookRefetch();
+      } else {
+        client.connect(marketId, publicKey?.toBase58() ?? null);
+        tradesClient.connect(marketId);
+      }
     }
     return () => {
       tradesPrefetchAbortRef.current?.abort();
+      orderbookRefetchAbortRef.current?.abort();
+      tradesRefetchAbortRef.current?.abort();
+      if (orderbookRefetchTimerRef.current) clearTimeout(orderbookRefetchTimerRef.current);
+      if (tradesRefetchTimerRef.current) clearTimeout(tradesRefetchTimerRef.current);
       client.disconnect();
+      v2Composite.disconnect();
       tradesClient.disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -245,17 +371,24 @@ export function useSSEStream() {
     if (prevMarketRef.current === marketId) return;
     prevMarketRef.current = marketId;
 
-    if (client.getState() === 'disconnected') {
-      client.connect(marketId, publicKey?.toBase58() ?? null);
+    if (v2Enabled) {
+      if (v2Composite.getState() === 'disconnected') {
+        v2Composite.connect(marketId, publicKey?.toBase58() ?? null);
+      } else {
+        v2Composite.switchMarket(marketId);
+      }
+      scheduleOrderbookRefetch();
     } else {
-      client.switchMarket(marketId);
-    }
-
-    // Switch trades stream too
-    if (tradesClient.getState() === 'disconnected') {
-      tradesClient.connect(marketId);
-    } else {
-      tradesClient.switchMarket(marketId);
+      if (client.getState() === 'disconnected') {
+        client.connect(marketId, publicKey?.toBase58() ?? null);
+      } else {
+        client.switchMarket(marketId);
+      }
+      if (tradesClient.getState() === 'disconnected') {
+        tradesClient.connect(marketId);
+      } else {
+        tradesClient.switchMarket(marketId);
+      }
     }
 
     // Clear stale trades and seed with REST prefetch for instant paint.
@@ -279,7 +412,11 @@ export function useSSEStream() {
       setAccountMetrics(null);
     }
 
-    if (client.getState() !== 'disconnected') {
+    if (v2Enabled) {
+      // ?owner= is bound at connect time on the gateway; reopen the stream
+      // so the account-scoped events fire for the new wallet.
+      v2Composite.switchOwner(ownerStr);
+    } else if (client.getState() !== 'disconnected') {
       client.switchOwner(ownerStr);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Feature-flagged port of the live-data path onto the gateway's `/v2/*` Redis-backed endpoints + the new composite `/v2/stream/frontend/:market` SSE. Gated by `VITE_USE_V2_READ_LAYER`; v1 stays behind the flag until the full migration is soaked.

## New modules (`src/shared/api/`)

- `v2-api.ts` — thin fetchers over `/v2/snapshot/*`, `/v2/trades`, `/v2/trades/wallet/:owner`, `/v2/markets`.
- `v2-adapter.ts` — shape translators from thin Redis-key-dump responses to the native-scaled atom shapes the UI renders. Keeps atom wiring unchanged.
- `v2-sse-client.ts` — single-market tail of `/v2/events/:market` (raw harness mutation events, used as an invalidation signal).
- `v2-composite-sse-client.ts` — subscriber for `/v2/stream/frontend/:market` that multiplexes `book` / `meta` / `trade` / `intent` / `account` events on one connection.

## Wiring changes

- `constants.ts` — adds `/v2/markets`, `/v2/candles`, `/v2/stats/volume/24h`, `/v2/stream/frontend`, `/v2/stream/trades` route consts and the `useV2ReadLayer` / `v2View` flags.
- `useSSEStream.ts` — when v2 is on, callbacks route through the composite client:
  - `book` event → debounced `/v2/snapshot/orderbook` refetch
  - `trade` + `intent` events → debounced `/v2/trades/:market` refetch
  - `ready` → eager trades seed
  - `resync` → refetch both
  Legacy dual-stream path preserved behind the flag.
- `walletTrades.ts` → `/v2/trades/wallet/:owner` when v2 is on; v1 fallback preserved.
- `perps-chart.ts` → `/v2/candles/:market` (Binance-kline-compatible) when v2 is on; falls back to `/ohlc/:market`.

## Connection count

- Before: 2 SSE (`/v2/events/:market` + `/state/stream/trades`) + REST poll.
- After: **1 SSE** (`/v2/stream/frontend/:market`).

## Not yet wired (explicitly deferred)

- `meta` → `marketMetricsAtom`: v1 path carries `name` / `mint` / `decimals` on `market_update.metadata`; v2 `meta` event today carries pricing only, until the harness-side snapshot identity wiring ([Fermi-DEX/mng-v4#16](https://github.com/Fermi-DEX/mng-v4/pull/16)) lands.
- `account` → user atoms: same shape-translation gap.

Both are no-ops when v2 is on today; v1 path still populates them through the composite client's invalidation signals + targeted REST refetches.

## Test plan

- [x] `pnpm typecheck` clean on both branches of the feature flag
- [x] Orderbook refetch fires on `book` event (verified against deployed gateway)
- [ ] Trade-panel hydrates with a real fill (gated on harness-side H3 landing upstream — see [Fermi-DEX/mng-v4#16](https://github.com/Fermi-DEX/mng-v4/pull/16))
- [ ] Chart renders candles from `/v2/candles` once trade stream starts producing data