### PR TITLE
v2: migrate remaining /state/balances callers to /v2/snapshot/account

### DIFF
--- a/src/pages/vault/index.tsx
+++ b/src/pages/vault/index.tsx
@@ -26,7 +26,13 @@ import { toast } from 'sonner';
 import posthog from 'posthog-js';
 import { config, API_ROUTES, API_ROUTES_V2 } from '@/shared/config/constants';
 import { Market } from '@/entities/market/model';
-import { mapV2MetaToMarket, type V2MetaEvent } from '@/shared/api/v2-adapter';
+import {
+  mapV2MetaToMarket,
+  mapV2AccountBalances,
+  type V2MetaEvent,
+  type V2AccountEvent,
+} from '@/shared/api/v2-adapter';
+import { baseMint, quoteMint } from '@/shared/config/constants';
 import { getTokenDecimals } from '@/shared/lib/token-decimals';
 
 interface Token {
@@ -122,11 +128,23 @@ function VaultPage() {
     }
   }, [tokens, selectedToken]);
 
-  // Fetch user balances from API
+  // Fetch user balances. v2 reads v1:balance:<owner>.{tokens,totals} via
+  // /v2/snapshot/account — no /state/balances round-trip. Legacy kept behind
+  // the flag during migration.
   const { data: balances } = useQuery({
-    queryKey: ['userBalances', publicKey?.toBase58()],
+    queryKey: ['userBalances', publicKey?.toBase58(), config.devnet.useV2ReadLayer],
     queryFn: async () => {
       if (!publicKey) return null;
+      if (config.devnet.useV2ReadLayer) {
+        const url = `${config.devnet.gatewayUrl}${API_ROUTES_V2.snapshot_account.replace('{owner}', publicKey.toBase58())}`;
+        const response = await axios.get<V2AccountEvent>(url);
+        return mapV2AccountBalances(response.data, {
+          baseMint: baseMint.toBase58(),
+          baseDecimals: config.devnet.baseDecimals ?? 9,
+          quoteMint: quoteMint.toBase58(),
+          quoteDecimals: config.devnet.quoteDecimals ?? 6,
+        });
+      }
       const url = `${config.devnet.gatewayUrl}${API_ROUTES.user_balances.replace('{pubkey}', publicKey.toBase58())}`;
       const response = await axios.get(url);
       return response.data as Record<string, { available: string; reserved: string }>;

--- a/src/shared/api/useSequencerApi.tsx
+++ b/src/shared/api/useSequencerApi.tsx
@@ -5,8 +5,9 @@
 import { useCallback } from 'react';
 import axios, { AxiosResponse } from 'axios';
 import { tryCatch } from '@/shared/lib/try-catch';
-import { config, quoteMint, API_ROUTES } from '../config/constants';
+import { config, quoteMint, baseMint, API_ROUTES, API_ROUTES_V2 } from '../config/constants';
 import { lotsQuoteToNative } from '@/shared/lib/harness-market';
+import { mapV2AccountBalances, type V2AccountEvent } from './v2-adapter';
 
 export interface Market {
   uuid: string;
@@ -206,6 +207,22 @@ export function useSequencerApi() {
 
   const fetchUserBalances = useCallback(
     async (pubkey: string): Promise<UserBalancesResponse> => {
+      // v2 path: /v2/snapshot/account/:owner carries `tokens` + `totals`
+      // under the Redis mirror. Mapper produces the same
+      // { [mint]: { available, reserved } } shape consumers expect.
+      if (config.devnet.useV2ReadLayer) {
+        const v2Url = `${harnessUrl}${API_ROUTES_V2.snapshot_account.replace('{owner}', pubkey)}`;
+        const { data: v2Data, error: v2Err } = await tryCatch<AxiosResponse<V2AccountEvent>>(
+          axios.get(v2Url)
+        );
+        if (v2Err) throw v2Err;
+        return mapV2AccountBalances(v2Data.data, {
+          baseMint: baseMint.toBase58(),
+          baseDecimals: config.devnet.baseDecimals ?? 9,
+          quoteMint: quoteMint.toBase58(),
+          quoteDecimals: config.devnet.quoteDecimals ?? 6,
+        });
+      }
       const url = `${harnessUrl}${API_ROUTES.user_balances.replace('{pubkey}', pubkey)}?view=optimistic`;
       const { data, error } = await tryCatch<AxiosResponse<HarnessBalancesResponse>>(
         axios.get(url)

--- a/src/shared/api/v2-adapter.ts
+++ b/src/shared/api/v2-adapter.ts
@@ -15,6 +15,8 @@ import type { Market, MarketKind } from '@/entities/market';
 import type { Order } from './useSequencerApi';
 import type { Position } from '@/shared/hooks/usePositions';
 import type { MarginAccount } from '@/shared/hooks/useAccount';
+import type { TokenBalance } from './useSequencerApi';
+import { lotsQuoteToNative } from '@/shared/lib/harness-market';
 
 // ── Orderbook ─────────────────────────────────────────────────────────
 // v2 snapshot delivers one entry per *order* (price + order_id + order detail).
@@ -276,6 +278,27 @@ export interface V2AccountEvent {
       client_id?: string | number | null;
     } | null;
   }>;
+  // Per-asset token balances, mirrored verbatim from the harness's
+  // optimistic-collateral computation (same shape as legacy
+  // `optimistic_collateral`). Null until the harness mirror extension lands.
+  tokens?: {
+    source?: string;
+    usdc_mint?: string;
+    usdc_ui_balance?: number;
+    tokens?: Array<{
+      token_index: number;
+      mint: string;
+      ui_balance: number;
+      ui_deposits: number;
+      ui_borrows: number;
+    }>;
+  } | null;
+  // Aggregate reserves across markets (same shape as legacy `totals`).
+  totals?: {
+    total_open_order_base_lots_bid?: string;
+    total_open_order_base_lots_ask?: string;
+    total_quote_reserved_lots?: string;
+  } | null;
 }
 
 function lotsPriceToUi(priceLots: number, ctx: MarketContext): number {
@@ -397,6 +420,71 @@ export function mapV2AccountMargin(event: V2AccountEvent, quoteDecimals: number)
 }
 
 // Best-bid / best-ask are derived from the `book` event's top-of-book,
+// `/v2/snapshot/account/:owner` → `{ [mint]: { available, reserved } }`,
+// the same shape the legacy `/state/balances` composer produced. Lets the
+// vault + MyAssets panels flip to v2 without changing their consumers.
+//
+// `event.tokens` is the legacy `optimistic_collateral` object mirrored
+// verbatim into Redis; `event.totals` is the legacy `totals` object. If
+// either is missing (harness mirror extension not yet deployed for this
+// owner), that portion simply contributes nothing — callers still get an
+// empty `{}` and can fall back / show loading state.
+export function mapV2AccountBalances(
+  event: V2AccountEvent,
+  ctx: {
+    baseMint: string;
+    baseDecimals: number;
+    quoteMint: string;
+    quoteDecimals: number;
+  }
+): Record<string, TokenBalance> {
+  const balances: Record<string, TokenBalance> = {};
+  const add = (mint: string, availableDelta: bigint, reservedDelta: bigint) => {
+    if (!mint) return;
+    const current = balances[mint] || { available: '0', reserved: '0' };
+    const available = BigInt(current.available || '0') + availableDelta;
+    const reserved = BigInt(current.reserved || '0') + reservedDelta;
+    balances[mint] = { available: available.toString(), reserved: reserved.toString() };
+  };
+  const toNativeString = (ui: number, decimals: number): string => {
+    if (!Number.isFinite(ui)) return '0';
+    const scaled = ui * Math.pow(10, Math.max(0, decimals));
+    if (!Number.isFinite(scaled)) return '0';
+    return Math.round(scaled).toString();
+  };
+
+  const tokensEntry = event.tokens ?? null;
+  const usdcMint = tokensEntry?.usdc_mint || '';
+  for (const token of tokensEntry?.tokens ?? []) {
+    const decimals =
+      token.mint === usdcMint
+        ? 6
+        : token.mint === ctx.quoteMint
+          ? Math.max(0, ctx.quoteDecimals)
+          : token.mint === ctx.baseMint
+            ? Math.max(0, ctx.baseDecimals)
+            : 9;
+    const availableNative = BigInt(toNativeString(token.ui_balance, decimals));
+    add(token.mint, availableNative, 0n);
+    // Preserve compatibility with frontend configs whose quote mint differs
+    // from the harness USDC mint (legacy placeholder configs).
+    if (token.mint === usdcMint && usdcMint && usdcMint !== ctx.quoteMint) {
+      add(ctx.quoteMint, availableNative, 0n);
+    }
+  }
+
+  const quoteReservedNative = BigInt(
+    lotsQuoteToNative(event.totals?.total_quote_reserved_lots || '0')
+  );
+  const quoteMintFromHarness = tokensEntry?.usdc_mint || ctx.quoteMint;
+  add(quoteMintFromHarness, 0n, quoteReservedNative);
+  if (quoteMintFromHarness !== ctx.quoteMint) {
+    add(ctx.quoteMint, 0n, quoteReservedNative);
+  }
+
+  return balances;
+}
+
 // since the meta event today only carries hash fields. Reuse the same
 // orderbook shape we already aggregate for `orderbookAtom`.
 export function bestBidAskFromBook(


### PR DESCRIPTION
## Summary

Last two `/state/balances` call sites move to the Redis-backed read layer. Closes the frontend side of the v2 rollout.

| File | Before | After |
|---|---|---|
| `pages/vault/index.tsx:126` | `GET /state/balances/{pubkey}` unconditionally | v2 path via `/v2/snapshot/account/{owner}` + `mapV2AccountBalances`, legacy behind flag |
| `shared/api/useSequencerApi.tsx:207` (`fetchUserBalances`, consumed by `MyAssets.tsx`) | same | same |

## How it works

Both consumers expect `{ [mint]: { available, reserved } }`. The gateway's `/v2/snapshot/account` returns `tokens` (per-asset UI balances) and `totals` (aggregate reserves) at the top level — mirrored verbatim from `v1:balance:<owner>.{tokens,totals}` by the harness state-mirror.

Added `mapV2AccountBalances(event, ctx)` in [v2-adapter.ts](../../shared/api/v2-adapter.ts) that produces the legacy shape from the v2 response. Shared by both callers.

## Dependencies

- Gateway already serves `/v2/snapshot/account/:owner` with `tokens` + `totals` fields (continuum-proxy-rust commit `3972696`).
- Harness mirror extension shipping in Fermi-DEX/mng-v4#21 (per-owner collateral refresh). Until that deploys, `tokens`/`totals` may be null for some owners and this path returns `{}` — matches legacy behaviour when the harness hadn't computed optimistic_collateral yet.

## Test plan

- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — clean on changed files (pre-existing repo warnings untouched)
- [ ] Flag off → vault + MyAssets still fetch from `/state/balances` (unchanged)
- [ ] Flag on, Fermi-DEX/mng-v4#21 deployed → vault + MyAssets show non-zero balances sourced from `/v2/snapshot/account`
- [ ] Flag on, harness mirror not yet populated for an owner → consumers see `{}`, no crashes (graceful empty state)

## Notes

- No changes to `/state/deposit-context` callers (`useMangoMarginDeposit`, `usePerps`) — that endpoint is a tx-construction helper returning program_id / group / quote_bank / health_remaining_accounts, not read-layer display data. Stays on the harness.
- Legacy `HarnessBalancesResponse` type + legacy code path retained unchanged for rollback.